### PR TITLE
Always remove the start clock window when closing the menu

### DIFF
--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -550,12 +550,10 @@ static void RemoveExtraStartMenuWindows(void)
         ClearStdWindowAndFrameToTransparent(sBattlePyramidFloorWindowId, FALSE);
         RemoveWindow(sBattlePyramidFloorWindowId);
     }
-    else
-    {
-        ClearStdWindowAndFrameToTransparent(sStartClockWindowId, FALSE);
-        // CopyWindowToVram(sStartClockWindowId, COPYWIN_GFX);
-        RemoveWindow(sStartClockWindowId);
-    }
+    
+    ClearStdWindowAndFrameToTransparent(sStartClockWindowId, FALSE);
+    // CopyWindowToVram(sStartClockWindowId, COPYWIN_GFX);
+    RemoveWindow(sStartClockWindowId);
 }
 
 static bool32 PrintStartMenuActions(s8 *pIndex, u32 count)


### PR DESCRIPTION
If you close the start menu in the safari zone, the clock window doesnt get cleared. Removing this "else" ensure it does get cleared!