### PR TITLE
Initial pass at sleep clause cleanup

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -603,9 +603,8 @@ struct BattleGimmickData
 
 struct SleepClauseData
 {
-    u8 isActive[NUM_BATTLE_SIDES]; // Stores sleep clause state for each battle side
-    bool8 effectExempt; // Stores whether effect should be exempt from triggering sleep clause (Effect Spore)
-    bool8 isCausingSleepClause[NUM_BATTLE_SIDES][PARTY_SIZE]; // When a Pokemon falls asleep, need to know if it should deactivate sleep clause upon waking
+    bool8 effectExempt; // Stores whether effect should be exempt from triggering Sleep Clause (Effect Spore)
+    u8 isCausingSleepClause[NUM_BATTLE_SIDES]; // stores which pokemon on a given side is causing Sleep Clause to be active as a bitfield
 };
 
 struct LostItem

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -300,7 +300,7 @@ bool8 CanMonParticipateInSkyBattle(struct Pokemon *mon);
 bool8 IsMonBannedFromSkyBattles(u16 species);
 void RemoveBattlerType(u32 battler, u8 type);
 u32 GetMoveType(u32 move);
-void TryActivateSleepClause(u32 battler);
+void TryActivateSleepClause(u32 battlerSide, u32 indexInParty);
 void TryDeactivateSleepClause(u32 battlerSide, u32 indexInParty);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -300,5 +300,7 @@ bool8 CanMonParticipateInSkyBattle(struct Pokemon *mon);
 bool8 IsMonBannedFromSkyBattles(u16 species);
 void RemoveBattlerType(u32 battler, u8 type);
 u32 GetMoveType(u32 move);
+void TryActivateSleepClause(u32 battler);
+void TryDeactivateSleepClause(u32 battler);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -301,6 +301,6 @@ bool8 IsMonBannedFromSkyBattles(u16 species);
 void RemoveBattlerType(u32 battler, u8 type);
 u32 GetMoveType(u32 move);
 void TryActivateSleepClause(u32 battler);
-void TryDeactivateSleepClause(u32 battler);
+void TryDeactivateSleepClause(u32 battlerSide, u32 indexInParty);
 
 #endif // GUARD_BATTLE_UTIL_H

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -890,12 +890,8 @@ void BS_TrySetStatus1(void)
                     gBattleMons[gBattlerTarget].status1 |=  STATUS1_SLEEP_TURN((Random() % 3) + 2);
                 else
                     gBattleMons[gBattlerTarget].status1 |=  STATUS1_SLEEP_TURN((Random() % 4) + 3);
-                if (FlagGet(B_FLAG_SLEEP_CLAUSE))
-                {
-                    gBattleStruct->sleepClause.isActive[GetBattlerSide(gBattlerTarget)] = TRUE;
-                    gBattleStruct->sleepClause.isCausingSleepClause[GetBattlerSide(gBattlerTarget)][gBattlerPartyIndexes[gBattlerTarget]] = TRUE;
-                }
-                    
+                
+                TryActivateSleepClause(gBattlerTarget);    
                 gBattleCommunication[MULTISTRING_CHOOSER] = 4;
                 effect++;
             }

--- a/src/battle_dynamax.c
+++ b/src/battle_dynamax.c
@@ -891,7 +891,8 @@ void BS_TrySetStatus1(void)
                 else
                     gBattleMons[gBattlerTarget].status1 |=  STATUS1_SLEEP_TURN((Random() % 4) + 3);
                 
-                TryActivateSleepClause(gBattlerTarget);    
+                // Try to activate Sleep Clause when a mon is put to Sleep
+                TryActivateSleepClause(GetBattlerSide(gBattlerTarget), gBattlerPartyIndexes[gBattlerTarget]);    
                 gBattleCommunication[MULTISTRING_CHOOSER] = 4;
                 effect++;
             }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3225,8 +3225,8 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
             {
                 if (UproarWakeUpCheck(gBattlerAttacker))
                 {
-                    TryDeactivateSleepClause(gBattlerAttacker);
-
+                    // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via Uproar
+                    TryDeactivateSleepClause(GetBattlerSide(gBattlerAttacker), gBattlerPartyIndexes[gBattlerAttacker]);
                     gBattleMons[gBattlerAttacker].status1 &= ~STATUS1_SLEEP;
                     gBattleMons[gBattlerAttacker].status2 &= ~STATUS2_NIGHTMARE;
                     BattleScriptPushCursor();
@@ -3256,7 +3256,8 @@ u8 AtkCanceller_UnableToUseMove(u32 moveType)
                     }
                     else
                     {
-                        TryDeactivateSleepClause(gBattlerAttacker);
+                        // Try to deactivate Sleep Clause when a mon wakes up
+                        TryDeactivateSleepClause(GetBattlerSide(gBattlerAttacker), gBattlerPartyIndexes[gBattlerAttacker]);
                         gBattleMons[gBattlerAttacker].status2 &= ~STATUS2_NIGHTMARE;
                         BattleScriptPushCursor();
                         gBattleCommunication[MULTISTRING_CHOOSER] = B_MSG_WOKE_UP;
@@ -5144,7 +5145,8 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                     if (gBattleMons[battler].status1 & STATUS1_SLEEP)
                     {
                         StringCopy(gBattleTextBuff1, gStatusConditionString_SleepJpn);
-                        TryDeactivateSleepClause(battler);
+                        // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via Shed Skin, Hydration
+                        TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                     }
                         
                     if (gBattleMons[battler].status1 & STATUS1_PARALYSIS)
@@ -5235,9 +5237,6 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
                     && gBattleMons[gBattleScripting.battler].status1 & STATUS1_ANY
                     && RandomPercentage(RNG_HEALER, 30))
                 {
-                    if (gBattleMons[gBattleScripting.battler].status1 & STATUS1_SLEEP)
-                        TryDeactivateSleepClause(gBattleScripting.battler);
-
                     BattleScriptPushCursorAndCallback(BattleScript_HealerActivates);
                     effect++;
                 }
@@ -6191,7 +6190,8 @@ u32 AbilityBattleEffects(u32 caseID, u32 battler, u32 ability, u32 special, u32 
             case ABILITY_VITAL_SPIRIT:
                 if (gBattleMons[battler].status1 & STATUS1_SLEEP)
                 {
-                    TryDeactivateSleepClause(battler);
+                    // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via gaining the ability Insomnia or Vital Spirit
+                    TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                     gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                     StringCopy(gBattleTextBuff1, gStatusConditionString_SleepJpn);
                     effect = 1;
@@ -7277,7 +7277,8 @@ static u8 ItemEffectMoveEnd(u32 battler, u16 holdEffect)
             BattleScriptPushCursor();
             gBattlescriptCurrInstr = BattleScript_BerryCureSlpRet;
             effect = ITEM_STATUS_CHANGE;
-            TryDeactivateSleepClause(battler);
+            // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Chesto Berry
+            TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
         }
         break;
     case HOLD_EFFECT_CURE_CONFUSION:
@@ -7309,6 +7310,8 @@ static u8 ItemEffectMoveEnd(u32 battler, u16 holdEffect)
             {
                 gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                 StringCopy(gBattleTextBuff1, gStatusConditionString_SleepJpn);
+                // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Lum Berry
+                TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
             }
 
             if (gBattleMons[battler].status1 & STATUS1_PARALYSIS)
@@ -7519,7 +7522,8 @@ u8 ItemBattleEffects(u8 caseID, u32 battler, bool32 moveTurn)
                     gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                     BattleScriptExecute(BattleScript_BerryCureSlpEnd2);
                     effect = ITEM_STATUS_CHANGE;
-                    TryDeactivateSleepClause(battler);
+                    // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Chesto Berry
+                    TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                 }
                 break;
             case HOLD_EFFECT_CURE_STATUS:
@@ -7538,6 +7542,8 @@ u8 ItemBattleEffects(u8 caseID, u32 battler, bool32 moveTurn)
                         gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                         StringCopy(gBattleTextBuff1, gStatusConditionString_SleepJpn);
                         i++;
+                        // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Lum Berry
+                        TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                     }
                     if (gBattleMons[battler].status1 & STATUS1_PARALYSIS)
                     {
@@ -7827,7 +7833,8 @@ u8 ItemBattleEffects(u8 caseID, u32 battler, bool32 moveTurn)
                     gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                     BattleScriptExecute(BattleScript_BerryCureSlpEnd2);
                     effect = ITEM_STATUS_CHANGE;
-                    TryDeactivateSleepClause(battler);
+                    // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Chesto Berry
+                    TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                 }
                 break;
             case HOLD_EFFECT_CURE_CONFUSION:
@@ -7852,6 +7859,8 @@ u8 ItemBattleEffects(u8 caseID, u32 battler, bool32 moveTurn)
                         gBattleMons[battler].status2 &= ~STATUS2_NIGHTMARE;
                         StringCopy(gBattleTextBuff1, gStatusConditionString_SleepJpn);
                         i++;
+                        // Try to deactivate Sleep Clause when a mon gets woken up by curing sleep via a Lum Berry
+                        TryDeactivateSleepClause(GetBattlerSide(battler), gBattlerPartyIndexes[battler]);
                     }
                     if (gBattleMons[battler].status1 & STATUS1_PARALYSIS)
                     {
@@ -11893,16 +11902,14 @@ void TryActivateSleepClause(u32 battler)
     gBattleStruct->sleepClause.isCausingSleepClause[side][gBattlerPartyIndexes[battler]] = TRUE;
 }
 
-void TryDeactivateSleepClause(u32 battler)
+void TryDeactivateSleepClause(u32 battlerSide, u32 indexInParty)
 {
     if (!FlagGet(B_FLAG_SLEEP_CLAUSE))
         return;
 
-    u32 side = GetBattlerSide(battler);
-
-    if (gBattleStruct->sleepClause.isActive[side] && gBattleStruct->sleepClause.isCausingSleepClause[side][gBattlerPartyIndexes[battler]])
+    if (gBattleStruct->sleepClause.isActive[battlerSide] && gBattleStruct->sleepClause.isCausingSleepClause[battlerSide][indexInParty])
     {
-        gBattleStruct->sleepClause.isActive[side] = FALSE;
-        gBattleStruct->sleepClause.isCausingSleepClause[side][gBattlerPartyIndexes[battler]] = FALSE;
+        gBattleStruct->sleepClause.isActive[battlerSide] = FALSE;
+        gBattleStruct->sleepClause.isCausingSleepClause[battlerSide][indexInParty] = FALSE;
     }
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4183,6 +4183,7 @@ bool8 HealStatusConditions(struct Pokemon *mon, u32 healMask, u8 battlerId)
         SetMonData(mon, MON_DATA_STATUS, &status);
         if (gMain.inBattle && battlerId != MAX_BATTLERS_COUNT)
         {
+            // TODO sleep clause: revisit this and see if it can be cleaned up
             gBattleMons[battlerId].status1 &= ~healMask;
             if((healMask & STATUS1_SLEEP) && FlagGet(B_FLAG_SLEEP_CLAUSE) && gBattleStruct->sleepClause.isActive[battlerSide])
             {


### PR DESCRIPTION
Initial pass at sleep clause cleanup, namely started using a bitfield for `isCausingSleepClause`, was able to remove `isActive`, put sleep clause activation / deactivation code into respective functions, and added some documentation comments